### PR TITLE
refactor(CitusProvider): Remove duplicate: Remove the mapActions method

### DIFF
--- a/src/sqlancer/citus/CitusProvider.java
+++ b/src/sqlancer/citus/CitusProvider.java
@@ -121,7 +121,6 @@ public class CitusProvider extends PostgresProvider {
         }
     }
 
-
     private class CitusWorkerNode {
 
         private final String host;
@@ -389,8 +388,8 @@ public class CitusProvider extends PostgresProvider {
 
     @Override
     protected void prepareTables(PostgresGlobalState globalState) throws Exception {
-        StatementExecutor<PostgresGlobalState, PostgresProvider.Action> se = new StatementExecutor<>(globalState, PostgresProvider.Action.values(),
-                PostgresProvider::mapActions, (q) -> {
+        StatementExecutor<PostgresGlobalState, PostgresProvider.Action> se = new StatementExecutor<>(globalState,
+                PostgresProvider.Action.values(), PostgresProvider::mapActions, (q) -> {
                     if (globalState.getSchema().getDatabaseTables().isEmpty()) {
                         throw new IgnoreMeException();
                     }

--- a/src/sqlancer/citus/CitusProvider.java
+++ b/src/sqlancer/citus/CitusProvider.java
@@ -121,65 +121,6 @@ public class CitusProvider extends PostgresProvider {
         }
     }
 
-    private static int mapActions(PostgresGlobalState globalState, Action a) {
-        Randomly r = globalState.getRandomly();
-        int nrPerformed;
-        switch (a) {
-        case CREATE_INDEX:
-        case CLUSTER:
-            nrPerformed = r.getInteger(0, 3);
-            break;
-        case CREATE_STATISTICS:
-            nrPerformed = r.getInteger(0, 5);
-            break;
-        case DISCARD:
-        case DROP_INDEX:
-            nrPerformed = r.getInteger(0, 5);
-            break;
-        case COMMIT:
-            nrPerformed = r.getInteger(0, 0);
-            break;
-        case ALTER_TABLE:
-            nrPerformed = r.getInteger(0, 5);
-            break;
-        case REINDEX:
-        case RESET:
-            nrPerformed = r.getInteger(0, 3);
-            break;
-        case DELETE:
-        case RESET_ROLE:
-        case SET:
-            nrPerformed = r.getInteger(0, 5);
-            break;
-        case ANALYZE:
-            nrPerformed = r.getInteger(0, 3);
-            break;
-        case VACUUM:
-        case SET_CONSTRAINTS:
-        case COMMENT_ON:
-        case NOTIFY:
-        case LISTEN:
-        case UNLISTEN:
-        case CREATE_SEQUENCE:
-        case DROP_STATISTICS:
-        case TRUNCATE:
-            nrPerformed = r.getInteger(0, 2);
-            break;
-        case CREATE_VIEW:
-            nrPerformed = r.getInteger(0, 2);
-            break;
-        case UPDATE:
-            nrPerformed = r.getInteger(0, 10);
-            break;
-        case INSERT:
-            nrPerformed = r.getInteger(0, globalState.getOptions().getMaxNumberInserts());
-            break;
-        default:
-            throw new AssertionError(a);
-        }
-        return nrPerformed;
-
-    }
 
     private class CitusWorkerNode {
 
@@ -448,8 +389,8 @@ public class CitusProvider extends PostgresProvider {
 
     @Override
     protected void prepareTables(PostgresGlobalState globalState) throws Exception {
-        StatementExecutor<PostgresGlobalState, Action> se = new StatementExecutor<>(globalState, Action.values(),
-                CitusProvider::mapActions, (q) -> {
+        StatementExecutor<PostgresGlobalState, PostgresProvider.Action> se = new StatementExecutor<>(globalState, PostgresProvider.Action.values(),
+                PostgresProvider::mapActions, (q) -> {
                     if (globalState.getSchema().getDatabaseTables().isEmpty()) {
                         throw new IgnoreMeException();
                     }

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -130,7 +130,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         }
     }
 
-    protected static int mapActions(PostgresGlobalState globalState, Action a) {
+    public static int mapActions(PostgresGlobalState globalState, Action a) {
         Randomly r = globalState.getRandomly();
         int nrPerformed;
         switch (a) {


### PR DESCRIPTION
# Things done

- Removed the `mapActions` method in `CitusProvider`
- Replaced the `mapActions` used in `CitusProvider` with the one in `PostgresProvider` since citus is an extension of Postgres