### PR TITLE
refactor(<DB>Constant): Extract toString: Remove dupe lines

### DIFF
--- a/src/sqlancer/cockroachdb/ast/CockroachDBConstant.java
+++ b/src/sqlancer/cockroachdb/ast/CockroachDBConstant.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import sqlancer.Randomly;
 import sqlancer.cockroachdb.CockroachDBVisitor;
+import sqlancer.common.constant.DoubleConstantUtil;
 
 public class CockroachDBConstant implements CockroachDBExpression {
 
@@ -54,12 +55,8 @@ public class CockroachDBConstant implements CockroachDBExpression {
 
         @Override
         public String toString() {
-            if (value == Double.POSITIVE_INFINITY) {
-                return "FLOAT '+Inf'";
-            } else if (value == Double.NEGATIVE_INFINITY) {
-                return "FLOAT '-Inf'";
-            }
-            return String.valueOf(value);
+            return DoubleConstantUtil.doubleToString(value, DoubleConstantUtil.COCKROACHDB_POSITIVE_INFINITY,
+                    DoubleConstantUtil.COCKROACHDB_NEGATIVE_INFINITY);
         }
 
     }

--- a/src/sqlancer/common/constant/DoubleConstantUtil.java
+++ b/src/sqlancer/common/constant/DoubleConstantUtil.java
@@ -1,0 +1,34 @@
+package sqlancer.common.constant;
+
+public final class DoubleConstantUtil {
+
+    public static final String TIDB_POSITIVE_INFINITY = "'+Inf'";
+    public static final String TIDB_NEGATIVE_INFINITY = "'-Inf'";
+
+    public static final String DUCKDB_POSITIVE_INFINITY = "'+Inf'";
+    public static final String DUCKDB_NEGATIVE_INFINITY = "'-Inf'";
+
+    public static final String HSQLDB_POSITIVE_INFINITY = "1.0e1/0.0e1";
+    public static final String HSQLDB_NEGATIVE_INFINITY = "-1.0e1/0.0e1";
+
+    public static final String YCQL_POSITIVE_INFINITY = "'+Inf'";
+    public static final String YCQL_NEGATIVE_INFINITY = "'-Inf'";
+
+    public static final String COCKROACHDB_POSITIVE_INFINITY = "FLOAT '+Inf'";
+    public static final String COCKROACHDB_NEGATIVE_INFINITY = "FLOAT '-Inf'";
+
+    public static final String PRESTO_POSITIVE_INFINITY = "infinity()";
+    public static final String PRESTO_NEGATIVE_INFINITY = "-infinity()";
+
+    private DoubleConstantUtil() {
+    }
+
+    public static String doubleToString(double value, String posInf, String negInf) {
+        if (value == Double.POSITIVE_INFINITY) {
+            return posInf;
+        } else if (value == Double.NEGATIVE_INFINITY) {
+            return negInf;
+        }
+        return String.valueOf(value);
+    }
+}

--- a/src/sqlancer/duckdb/ast/DuckDBConstant.java
+++ b/src/sqlancer/duckdb/ast/DuckDBConstant.java
@@ -1,5 +1,7 @@
 package sqlancer.duckdb.ast;
 
+import sqlancer.common.constant.DoubleConstantUtil;
+
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 
@@ -50,12 +52,8 @@ public class DuckDBConstant implements DuckDBExpression {
 
         @Override
         public String toString() {
-            if (value == Double.POSITIVE_INFINITY) {
-                return "'+Inf'";
-            } else if (value == Double.NEGATIVE_INFINITY) {
-                return "'-Inf'";
-            }
-            return String.valueOf(value);
+            return DoubleConstantUtil.doubleToString(value, DoubleConstantUtil.DUCKDB_POSITIVE_INFINITY,
+                    DoubleConstantUtil.DUCKDB_NEGATIVE_INFINITY);
         }
 
     }

--- a/src/sqlancer/hsqldb/ast/HSQLDBConstant.java
+++ b/src/sqlancer/hsqldb/ast/HSQLDBConstant.java
@@ -1,5 +1,7 @@
 package sqlancer.hsqldb.ast;
 
+import sqlancer.common.constant.DoubleConstantUtil;
+
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 
@@ -50,12 +52,8 @@ public class HSQLDBConstant implements HSQLDBExpression {
 
         @Override
         public String toString() {
-            if (value == Double.POSITIVE_INFINITY) {
-                return "1.0e1/0.0e1";
-            } else if (value == Double.NEGATIVE_INFINITY) {
-                return "-1.0e1/0.0e1";
-            }
-            return String.valueOf(value);
+            return DoubleConstantUtil.doubleToString(value, DoubleConstantUtil.HSQLDB_POSITIVE_INFINITY,
+                    DoubleConstantUtil.HSQLDB_NEGATIVE_INFINITY);
         }
 
     }

--- a/src/sqlancer/presto/ast/PrestoConstant.java
+++ b/src/sqlancer/presto/ast/PrestoConstant.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
+import sqlancer.common.constant.DoubleConstantUtil;
 import sqlancer.presto.PrestoConstantUtils;
 import sqlancer.presto.PrestoSchema;
 
@@ -390,12 +391,8 @@ public abstract class PrestoConstant implements PrestoExpression {
 
         @Override
         public String toString() {
-            if (value == Double.POSITIVE_INFINITY) {
-                return "infinity()";
-            } else if (value == Double.NEGATIVE_INFINITY) {
-                return "-infinity()";
-            }
-            return String.valueOf(value);
+            return DoubleConstantUtil.doubleToString(value, DoubleConstantUtil.PRESTO_POSITIVE_INFINITY,
+                    DoubleConstantUtil.PRESTO_NEGATIVE_INFINITY);
         }
 
         @Override

--- a/src/sqlancer/tidb/ast/TiDBConstant.java
+++ b/src/sqlancer/tidb/ast/TiDBConstant.java
@@ -1,5 +1,7 @@
 package sqlancer.tidb.ast;
 
+import sqlancer.common.constant.DoubleConstantUtil;
+
 public class TiDBConstant implements TiDBExpression {
 
     private TiDBConstant() {
@@ -47,12 +49,8 @@ public class TiDBConstant implements TiDBExpression {
 
         @Override
         public String toString() {
-            if (value == Double.POSITIVE_INFINITY) {
-                return "'+Inf'";
-            } else if (value == Double.NEGATIVE_INFINITY) {
-                return "'-Inf'";
-            }
-            return String.valueOf(value);
+            return DoubleConstantUtil.doubleToString(value, DoubleConstantUtil.TIDB_POSITIVE_INFINITY,
+                    DoubleConstantUtil.TIDB_NEGATIVE_INFINITY);
         }
 
     }

--- a/src/sqlancer/yugabyte/ycql/ast/YCQLConstant.java
+++ b/src/sqlancer/yugabyte/ycql/ast/YCQLConstant.java
@@ -1,5 +1,7 @@
 package sqlancer.yugabyte.ycql.ast;
 
+import sqlancer.common.constant.DoubleConstantUtil;
+
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 
@@ -50,12 +52,8 @@ public class YCQLConstant implements YCQLExpression {
 
         @Override
         public String toString() {
-            if (value == Double.POSITIVE_INFINITY) {
-                return "'+Inf'";
-            } else if (value == Double.NEGATIVE_INFINITY) {
-                return "'-Inf'";
-            }
-            return String.valueOf(value);
+            return DoubleConstantUtil.doubleToString(value, DoubleConstantUtil.YCQL_POSITIVE_INFINITY,
+                    DoubleConstantUtil.YCQL_NEGATIVE_INFINITY);
         }
 
     }


### PR DESCRIPTION
# Things done
Abstracted a doubleToString method for the following classes:
- `TiDBConstant`
- `DuckDBConstant`
- `HSQLDBConstant`
- `YCQLConstant`
- `CockroachDBConstant`
- `PrestoConstant`

Added a `DoubleConstantUtil` class for the doubleToString method
