### PR TITLE
Isolate compilation for databases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,5 +538,43 @@
         </plugins>
       </build>
     </profile>
+
+    <!-- Postgres Profile -->
+    <profile>
+      <id>postgres</id>
+      <activation>
+        <property>
+          <name>db</name>
+          <value>postgres</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>sqlancer/common/**</include>
+                <include>sqlancer/transformations/**</include>
+                <include>sqlancer/*.java</include>
+                <include>sqlancer/postgres/**</include>
+              </includes>
+            </configuration>
+            <executions>
+              <execution>
+                <id>default-testCompile</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -538,43 +538,5 @@
         </plugins>
       </build>
     </profile>
-
-    <!-- Postgres Profile -->
-    <profile>
-      <id>postgres</id>
-      <activation>
-        <property>
-          <name>db</name>
-          <value>postgres</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <includes>
-                <include>sqlancer/common/**</include>
-                <include>sqlancer/transformations/**</include>
-                <include>sqlancer/*.java</include>
-                <include>sqlancer/postgres/**</include>
-              </includes>
-            </configuration>
-            <executions>
-              <execution>
-                <id>default-testCompile</id>
-                <phase>test-compile</phase>
-                <goals>
-                  <goal>testCompile</goal>
-                </goals>
-                <configuration>
-                  <skip>true</skip>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -23,29 +23,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.JCommander.Builder;
 
-import sqlancer.citus.CitusProvider;
-import sqlancer.clickhouse.ClickHouseProvider;
-import sqlancer.cnosdb.CnosDBProvider;
-import sqlancer.cockroachdb.CockroachDBProvider;
 import sqlancer.common.log.Loggable;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.SQLancerResultSet;
-import sqlancer.databend.DatabendProvider;
-import sqlancer.doris.DorisProvider;
-import sqlancer.duckdb.DuckDBProvider;
-import sqlancer.h2.H2Provider;
-import sqlancer.hsqldb.HSQLDBProvider;
-import sqlancer.mariadb.MariaDBProvider;
-import sqlancer.materialize.MaterializeProvider;
-import sqlancer.mysql.MySQLProvider;
-import sqlancer.oceanbase.OceanBaseProvider;
-import sqlancer.postgres.PostgresProvider;
-import sqlancer.presto.PrestoProvider;
-import sqlancer.questdb.QuestDBProvider;
-import sqlancer.sqlite3.SQLite3Provider;
-import sqlancer.tidb.TiDBProvider;
-import sqlancer.yugabyte.ycql.YCQLProvider;
-import sqlancer.yugabyte.ysql.YSQLProvider;
 
 public final class Main {
 
@@ -718,36 +698,7 @@ public final class Main {
         for (DatabaseProvider<?, ?, ?> provider : loader) {
             providers.add(provider);
         }
-        checkForIssue799(providers);
         return providers;
-    }
-
-    // see https://github.com/sqlancer/sqlancer/issues/799
-    private static void checkForIssue799(List<DatabaseProvider<?, ?, ?>> providers) {
-        if (providers.isEmpty()) {
-            System.err.println(
-                    "No DBMS implementations (i.e., instantiations of the DatabaseProvider class) were found. You likely ran into an issue described in https://github.com/sqlancer/sqlancer/issues/799. As a workaround, I now statically load all supported providers as of June 7, 2023.");
-            providers.add(new CitusProvider());
-            providers.add(new ClickHouseProvider());
-            providers.add(new CnosDBProvider());
-            providers.add(new CockroachDBProvider());
-            providers.add(new DatabendProvider());
-            providers.add(new DorisProvider());
-            providers.add(new DuckDBProvider());
-            providers.add(new H2Provider());
-            providers.add(new HSQLDBProvider());
-            providers.add(new MariaDBProvider());
-            providers.add(new MaterializeProvider());
-            providers.add(new MySQLProvider());
-            providers.add(new OceanBaseProvider());
-            providers.add(new PrestoProvider());
-            providers.add(new PostgresProvider());
-            providers.add(new QuestDBProvider());
-            providers.add(new SQLite3Provider());
-            providers.add(new TiDBProvider());
-            providers.add(new YCQLProvider());
-            providers.add(new YSQLProvider());
-        }
     }
 
     private static synchronized void startProgressMonitor() {

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -23,29 +23,29 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.JCommander.Builder;
 
-//import sqlancer.citus.CitusProvider;
-//import sqlancer.clickhouse.ClickHouseProvider;
-//import sqlancer.cnosdb.CnosDBProvider;
-//import sqlancer.cockroachdb.CockroachDBProvider;
+import sqlancer.citus.CitusProvider;
+import sqlancer.clickhouse.ClickHouseProvider;
+import sqlancer.cnosdb.CnosDBProvider;
+import sqlancer.cockroachdb.CockroachDBProvider;
 import sqlancer.common.log.Loggable;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.SQLancerResultSet;
-//import sqlancer.databend.DatabendProvider;
-//import sqlancer.doris.DorisProvider;
-//import sqlancer.duckdb.DuckDBProvider;
-//import sqlancer.h2.H2Provider;
-//import sqlancer.hsqldb.HSQLDBProvider;
-//import sqlancer.mariadb.MariaDBProvider;
-//import sqlancer.materialize.MaterializeProvider;
-//import sqlancer.mysql.MySQLProvider;
-//import sqlancer.oceanbase.OceanBaseProvider;
-//import sqlancer.postgres.PostgresProvider;
-//import sqlancer.presto.PrestoProvider;
-//import sqlancer.questdb.QuestDBProvider;
-//import sqlancer.sqlite3.SQLite3Provider;
-//import sqlancer.tidb.TiDBProvider;
-//import sqlancer.yugabyte.ycql.YCQLProvider;
-//import sqlancer.yugabyte.ysql.YSQLProvider;
+import sqlancer.databend.DatabendProvider;
+import sqlancer.doris.DorisProvider;
+import sqlancer.duckdb.DuckDBProvider;
+import sqlancer.h2.H2Provider;
+import sqlancer.hsqldb.HSQLDBProvider;
+import sqlancer.mariadb.MariaDBProvider;
+import sqlancer.materialize.MaterializeProvider;
+import sqlancer.mysql.MySQLProvider;
+import sqlancer.oceanbase.OceanBaseProvider;
+import sqlancer.postgres.PostgresProvider;
+import sqlancer.presto.PrestoProvider;
+import sqlancer.questdb.QuestDBProvider;
+import sqlancer.sqlite3.SQLite3Provider;
+import sqlancer.tidb.TiDBProvider;
+import sqlancer.yugabyte.ycql.YCQLProvider;
+import sqlancer.yugabyte.ysql.YSQLProvider;
 
 public final class Main {
 
@@ -718,39 +718,37 @@ public final class Main {
         for (DatabaseProvider<?, ?, ?> provider : loader) {
             providers.add(provider);
         }
-        // checkForIssue799(providers);
+        checkForIssue799(providers);
         return providers;
     }
 
     // see https://github.com/sqlancer/sqlancer/issues/799
-    // private static void checkForIssue799(List<DatabaseProvider<?, ?, ?>> providers) {
-    // if (providers.isEmpty()) {
-    // System.err.println(
-    // "No DBMS implementations (i.e., instantiations of the DatabaseProvider class) were found. You likely ran into an
-    // issue described in https://github.com/sqlancer/sqlancer/issues/799. As a workaround, I now statically load all
-    // supported providers as of June 7, 2023.");
-    // providers.add(new CitusProvider());
-    // providers.add(new ClickHouseProvider());
-    // providers.add(new CnosDBProvider());
-    // providers.add(new CockroachDBProvider());
-    // providers.add(new DatabendProvider());
-    // providers.add(new DorisProvider());
-    // providers.add(new DuckDBProvider());
-    // providers.add(new H2Provider());
-    // providers.add(new HSQLDBProvider());
-    // providers.add(new MariaDBProvider());
-    // providers.add(new MaterializeProvider());
-    // providers.add(new MySQLProvider());
-    // providers.add(new OceanBaseProvider());
-    // providers.add(new PrestoProvider());
-    // providers.add(new PostgresProvider());
-    // providers.add(new QuestDBProvider());
-    // providers.add(new SQLite3Provider());
-    // providers.add(new TiDBProvider());
-    // providers.add(new YCQLProvider());
-    // providers.add(new YSQLProvider());
-    // }
-    // }
+    private static void checkForIssue799(List<DatabaseProvider<?, ?, ?>> providers) {
+        if (providers.isEmpty()) {
+            System.err.println(
+                    "No DBMS implementations (i.e., instantiations of the DatabaseProvider class) were found. You likely ran into an issue described in https://github.com/sqlancer/sqlancer/issues/799. As a workaround, I now statically load all supported providers as of June 7, 2023.");
+            providers.add(new CitusProvider());
+            providers.add(new ClickHouseProvider());
+            providers.add(new CnosDBProvider());
+            providers.add(new CockroachDBProvider());
+            providers.add(new DatabendProvider());
+            providers.add(new DorisProvider());
+            providers.add(new DuckDBProvider());
+            providers.add(new H2Provider());
+            providers.add(new HSQLDBProvider());
+            providers.add(new MariaDBProvider());
+            providers.add(new MaterializeProvider());
+            providers.add(new MySQLProvider());
+            providers.add(new OceanBaseProvider());
+            providers.add(new PrestoProvider());
+            providers.add(new PostgresProvider());
+            providers.add(new QuestDBProvider());
+            providers.add(new SQLite3Provider());
+            providers.add(new TiDBProvider());
+            providers.add(new YCQLProvider());
+            providers.add(new YSQLProvider());
+        }
+    }
 
     private static synchronized void startProgressMonitor() {
         if (progressMonitorStarted) {

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -23,29 +23,29 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.JCommander.Builder;
 
-import sqlancer.citus.CitusProvider;
-import sqlancer.clickhouse.ClickHouseProvider;
-import sqlancer.cnosdb.CnosDBProvider;
-import sqlancer.cockroachdb.CockroachDBProvider;
+//import sqlancer.citus.CitusProvider;
+//import sqlancer.clickhouse.ClickHouseProvider;
+//import sqlancer.cnosdb.CnosDBProvider;
+//import sqlancer.cockroachdb.CockroachDBProvider;
 import sqlancer.common.log.Loggable;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.SQLancerResultSet;
-import sqlancer.databend.DatabendProvider;
-import sqlancer.doris.DorisProvider;
-import sqlancer.duckdb.DuckDBProvider;
-import sqlancer.h2.H2Provider;
-import sqlancer.hsqldb.HSQLDBProvider;
-import sqlancer.mariadb.MariaDBProvider;
-import sqlancer.materialize.MaterializeProvider;
-import sqlancer.mysql.MySQLProvider;
-import sqlancer.oceanbase.OceanBaseProvider;
-import sqlancer.postgres.PostgresProvider;
-import sqlancer.presto.PrestoProvider;
-import sqlancer.questdb.QuestDBProvider;
-import sqlancer.sqlite3.SQLite3Provider;
-import sqlancer.tidb.TiDBProvider;
-import sqlancer.yugabyte.ycql.YCQLProvider;
-import sqlancer.yugabyte.ysql.YSQLProvider;
+//import sqlancer.databend.DatabendProvider;
+//import sqlancer.doris.DorisProvider;
+//import sqlancer.duckdb.DuckDBProvider;
+//import sqlancer.h2.H2Provider;
+//import sqlancer.hsqldb.HSQLDBProvider;
+//import sqlancer.mariadb.MariaDBProvider;
+//import sqlancer.materialize.MaterializeProvider;
+//import sqlancer.mysql.MySQLProvider;
+//import sqlancer.oceanbase.OceanBaseProvider;
+//import sqlancer.postgres.PostgresProvider;
+//import sqlancer.presto.PrestoProvider;
+//import sqlancer.questdb.QuestDBProvider;
+//import sqlancer.sqlite3.SQLite3Provider;
+//import sqlancer.tidb.TiDBProvider;
+//import sqlancer.yugabyte.ycql.YCQLProvider;
+//import sqlancer.yugabyte.ysql.YSQLProvider;
 
 public final class Main {
 
@@ -718,37 +718,39 @@ public final class Main {
         for (DatabaseProvider<?, ?, ?> provider : loader) {
             providers.add(provider);
         }
-        checkForIssue799(providers);
+        // checkForIssue799(providers);
         return providers;
     }
 
     // see https://github.com/sqlancer/sqlancer/issues/799
-    private static void checkForIssue799(List<DatabaseProvider<?, ?, ?>> providers) {
-        if (providers.isEmpty()) {
-            System.err.println(
-                    "No DBMS implementations (i.e., instantiations of the DatabaseProvider class) were found. You likely ran into an issue described in https://github.com/sqlancer/sqlancer/issues/799. As a workaround, I now statically load all supported providers as of June 7, 2023.");
-            providers.add(new CitusProvider());
-            providers.add(new ClickHouseProvider());
-            providers.add(new CnosDBProvider());
-            providers.add(new CockroachDBProvider());
-            providers.add(new DatabendProvider());
-            providers.add(new DorisProvider());
-            providers.add(new DuckDBProvider());
-            providers.add(new H2Provider());
-            providers.add(new HSQLDBProvider());
-            providers.add(new MariaDBProvider());
-            providers.add(new MaterializeProvider());
-            providers.add(new MySQLProvider());
-            providers.add(new OceanBaseProvider());
-            providers.add(new PrestoProvider());
-            providers.add(new PostgresProvider());
-            providers.add(new QuestDBProvider());
-            providers.add(new SQLite3Provider());
-            providers.add(new TiDBProvider());
-            providers.add(new YCQLProvider());
-            providers.add(new YSQLProvider());
-        }
-    }
+    // private static void checkForIssue799(List<DatabaseProvider<?, ?, ?>> providers) {
+    // if (providers.isEmpty()) {
+    // System.err.println(
+    // "No DBMS implementations (i.e., instantiations of the DatabaseProvider class) were found. You likely ran into an
+    // issue described in https://github.com/sqlancer/sqlancer/issues/799. As a workaround, I now statically load all
+    // supported providers as of June 7, 2023.");
+    // providers.add(new CitusProvider());
+    // providers.add(new ClickHouseProvider());
+    // providers.add(new CnosDBProvider());
+    // providers.add(new CockroachDBProvider());
+    // providers.add(new DatabendProvider());
+    // providers.add(new DorisProvider());
+    // providers.add(new DuckDBProvider());
+    // providers.add(new H2Provider());
+    // providers.add(new HSQLDBProvider());
+    // providers.add(new MariaDBProvider());
+    // providers.add(new MaterializeProvider());
+    // providers.add(new MySQLProvider());
+    // providers.add(new OceanBaseProvider());
+    // providers.add(new PrestoProvider());
+    // providers.add(new PostgresProvider());
+    // providers.add(new QuestDBProvider());
+    // providers.add(new SQLite3Provider());
+    // providers.add(new TiDBProvider());
+    // providers.add(new YCQLProvider());
+    // providers.add(new YSQLProvider());
+    // }
+    // }
 
     private static synchronized void startProgressMonitor() {
         if (progressMonitorStarted) {


### PR DESCRIPTION
Dealing with #53. Note that:

- In Main.java, code relating to issue 799 is removed. This is because the patch fix for 799 couples every implementation of the databases into Main, making it impossible for them to be isolated.
- To compile only for a certain db, run `mvn clean package -Dskiptests -P<db_name>`
- Currently, it is only possible to compile for a single database. So either 1 database or all, if invalid or no <db_name> is provided.