### PR TITLE
Isolate builds for databases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,5 +538,43 @@
         </plugins>
       </build>
     </profile>
+
+
+    <!-- Specific DB Profile -->
+    <profile>
+      <id>Isolate</id>
+      <activation>
+        <property>
+          <name>db</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>sqlancer/common/**</include>
+                <include>sqlancer/transformations/**</include>
+                <include>sqlancer/*.java</include>
+                <include>sqlancer/${db}/**/*.java</include>
+              </includes>
+            </configuration>
+            <executions>
+              <execution>
+                <id>default-testCompile</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -576,5 +576,44 @@
         </plugins>
       </build>
     </profile>
+
+    <!-- Citus Profile, special case -->
+    <profile>
+      <id>citus</id>
+      <activation>
+        <property>
+          <name>db</name>
+          <value>citus</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>sqlancer/common/**</include>
+                <include>sqlancer/transformations/**</include>
+                <include>sqlancer/*.java</include>
+                <include>sqlancer/citus/**</include>
+                <include>sqlancer/postgres/**</include>
+              </includes>
+            </configuration>
+            <executions>
+              <execution>
+                <id>default-testCompile</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -23,29 +23,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.JCommander.Builder;
 
-import sqlancer.citus.CitusProvider;
-import sqlancer.clickhouse.ClickHouseProvider;
-import sqlancer.cnosdb.CnosDBProvider;
-import sqlancer.cockroachdb.CockroachDBProvider;
 import sqlancer.common.log.Loggable;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.SQLancerResultSet;
-import sqlancer.databend.DatabendProvider;
-import sqlancer.doris.DorisProvider;
-import sqlancer.duckdb.DuckDBProvider;
-import sqlancer.h2.H2Provider;
-import sqlancer.hsqldb.HSQLDBProvider;
-import sqlancer.mariadb.MariaDBProvider;
-import sqlancer.materialize.MaterializeProvider;
-import sqlancer.mysql.MySQLProvider;
-import sqlancer.oceanbase.OceanBaseProvider;
-import sqlancer.postgres.PostgresProvider;
-import sqlancer.presto.PrestoProvider;
-import sqlancer.questdb.QuestDBProvider;
-import sqlancer.sqlite3.SQLite3Provider;
-import sqlancer.tidb.TiDBProvider;
-import sqlancer.yugabyte.ycql.YCQLProvider;
-import sqlancer.yugabyte.ysql.YSQLProvider;
 
 public final class Main {
 
@@ -718,36 +698,7 @@ public final class Main {
         for (DatabaseProvider<?, ?, ?> provider : loader) {
             providers.add(provider);
         }
-        checkForIssue799(providers);
         return providers;
-    }
-
-    // see https://github.com/sqlancer/sqlancer/issues/799
-    private static void checkForIssue799(List<DatabaseProvider<?, ?, ?>> providers) {
-        if (providers.isEmpty()) {
-            System.err.println(
-                    "No DBMS implementations (i.e., instantiations of the DatabaseProvider class) were found. You likely ran into an issue described in https://github.com/sqlancer/sqlancer/issues/799. As a workaround, I now statically load all supported providers as of June 7, 2023.");
-            providers.add(new CitusProvider());
-            providers.add(new ClickHouseProvider());
-            providers.add(new CnosDBProvider());
-            providers.add(new CockroachDBProvider());
-            providers.add(new DatabendProvider());
-            providers.add(new DorisProvider());
-            providers.add(new DuckDBProvider());
-            providers.add(new H2Provider());
-            providers.add(new HSQLDBProvider());
-            providers.add(new MariaDBProvider());
-            providers.add(new MaterializeProvider());
-            providers.add(new MySQLProvider());
-            providers.add(new OceanBaseProvider());
-            providers.add(new PrestoProvider());
-            providers.add(new PostgresProvider());
-            providers.add(new QuestDBProvider());
-            providers.add(new SQLite3Provider());
-            providers.add(new TiDBProvider());
-            providers.add(new YCQLProvider());
-            providers.add(new YSQLProvider());
-        }
     }
 
     private static synchronized void startProgressMonitor() {


### PR DESCRIPTION
Created maven profiles to isolate builds for a database, for #53. Note:

- Only 1 database can be loaded at a time, or the default all databases loaded. Cannot support a specific number of databases.
- To build, run `mvn clean package -Dskiptests -Ddb=<db_name>`
- In `Main.java`, the function to statically load all providers for database is removed, since it is impossible to only build from a single database package if the main file reads from all db packages. Functionality should remain the same if AutoService works as intended, see issue 799 in the main repo.