### PR TITLE
Script to exclude external maven dependencies

### DIFF
--- a/package.py
+++ b/package.py
@@ -1,0 +1,81 @@
+import subprocess
+import sys
+
+import xml.etree.ElementTree as ET
+
+dependency_map = {
+    'postgres': [('org.postgresql', 'postgresql', '42.5.1')],
+    'yugabyte': [('org.postgresql', 'postgresql', '42.5.1')],
+    'materialize': [('org.postgresql', 'postgresql', '42.5.1')],
+    'presto': [('com.ing.data', 'cassandra-jdbc-wrapper', '4.7.0')],
+    'clickhouse': [('ru.yandex.clickhouse', 'clickhouse-jdbc', '0.3.2')],
+    'cnosdb': [
+        ('com.arangodb', 'arangodb-java-driver', '6.9.0'),
+        ('org.apache.commons', 'commons-csv', '1.9.0')
+    ]
+}
+ns = {"mvn": "http://maven.apache.org/POM/4.0.0"}
+ET.register_namespace("", ns['mvn'])
+
+def clean_dep(tree):
+    dependencies = tree.getroot().find("./mvn:dependencies", ns)
+    to_remove = set([artifact_id for dep in dependency_map.values() for _, artifact_id, _ in dep])
+    removed_dep = []
+
+    for remove_dep in to_remove:
+        print(f"Removing {remove_dep}")
+        dep = dependencies.find(f"./mvn:dependency[mvn:artifactId='{remove_dep}']", ns)
+        removed_dep.append(dep)
+        dependencies.remove(dep)
+
+    return dependencies, removed_dep
+
+def insert_dep(profile, db):
+    db_dependencies = ET.Element("dependencies")
+    for group_id, artifact_id, version in dependency_map[db]:
+        db_dependency = ET.Element("dependency")
+        ET.SubElement(db_dependency, 'groupId').text = group_id
+        ET.SubElement(db_dependency, 'artifactId').text = artifact_id
+        ET.SubElement(db_dependency, 'version').text = version
+        db_dependencies.append(db_dependency)
+    profile.append(db_dependencies)
+
+def cleanup(tree, profile, to_add, dependencies):
+    if profile.find("dependencies", ns) is not None:
+        profile.remove(profile.find("dependencies", ns))
+    for add_dep in to_add:
+        dependencies.append(add_dep)
+    ET.indent(tree, '  ')
+    tree.write('pom.xml', encoding="utf-8", xml_declaration=True)
+
+def main():
+    # Build if no db specific
+    if len(sys.argv) < 2:
+        subprocess.run(['mvn', 'clean', 'package', '-DskipTests'])
+        return 1
+
+    tree = ET.parse('pom.xml')
+    db = sys.argv[1]
+
+    # Remove unnecessary dependencies
+    dependencies, removed = clean_dep(tree)
+
+    # Get profile to edit
+    profile = tree.getroot().find("./mvn:profiles/mvn:profile[mvn:id='Isolate']", ns)
+
+    # If db has specific dependency, add it
+    if db in dependency_map:
+        insert_dep(profile, db)
+
+    # Update pom.xml and compile
+    ET.indent(tree, '  ')
+    tree.write('pom.xml', encoding="utf-8", xml_declaration=True)
+    subprocess.run(['mvn', 'clean', 'package', '-DskipTests', f"-Ddb={db}"])
+
+    # Cleanup (prevent changes to pom.xml on git & prepare pom.xml for next use)
+    cleanup(tree, profile, removed, dependencies)
+
+    return 1
+
+if __name__ == "__main__":
+    main()

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.sqlancer</groupId>
   <artifactId>sqlancer</artifactId>
@@ -282,7 +281,6 @@
       </plugin>
     </plugins>
   </build>
-
   <dependencies>
     <dependency>
       <groupId>com.google.auto.service</groupId>
@@ -293,46 +291,6 @@
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
       <version>1.82</version>
-    </dependency>
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>42.5.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ing.data</groupId>
-      <artifactId>cassandra-jdbc-wrapper</artifactId>
-      <version>4.7.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yugabyte</groupId>
-      <artifactId>jdbc-yugabytedb</artifactId>
-      <version>42.3.5-yb-1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.xerial</groupId>
-      <artifactId>sqlite-jdbc</artifactId>
-      <version>3.47.2.0</version>
-    </dependency>
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.30</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mariadb.jdbc</groupId>
-      <artifactId>mariadb-java-client</artifactId>
-      <version>3.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.duckdb</groupId>
-      <artifactId>duckdb_jdbc</artifactId>
-      <version>1.1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.facebook.presto</groupId>
-      <artifactId>presto-jdbc</artifactId>
-      <version>0.283</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -346,19 +304,14 @@
       <version>2.0.6</version>
     </dependency>
     <dependency>
-      <groupId>ru.yandex.clickhouse</groupId>
-      <artifactId>clickhouse-jdbc</artifactId>
-      <version>0.3.2</version>
+      <groupId>com.github.jsqlparser</groupId>
+      <artifactId>jsqlparser</artifactId>
+      <version>4.6</version>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>2.3.232</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongodb-driver-sync</artifactId>
-      <version>4.1.1</version>
+      <groupId>com.ing.data</groupId>
+      <artifactId>cassandra-jdbc-wrapper</artifactId>
+      <version>4.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.arangodb</groupId>
@@ -366,30 +319,19 @@
       <version>6.9.0</version>
     </dependency>
     <dependency>
-      <groupId>org.questdb</groupId>
-      <artifactId>questdb</artifactId>
-      <version>6.5.3</version>
+      <groupId>ru.yandex.clickhouse</groupId>
+      <artifactId>clickhouse-jdbc</artifactId>
+      <version>0.3.2</version>
     </dependency>
     <dependency>
-      <groupId>org.hsqldb</groupId>
-      <artifactId>hsqldb</artifactId>
-      <version>2.7.1</version>
-      <scope>runtime</scope>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
       <version>1.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.github.jsqlparser</groupId>
-      <artifactId>jsqlparser</artifactId>
-      <version>4.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.arrow</groupId>
-      <artifactId>flight-sql-jdbc-driver</artifactId>
-      <version>16.1.0</version>
     </dependency>
   </dependencies>
   <reporting>
@@ -538,9 +480,6 @@
         </plugins>
       </build>
     </profile>
-
-
-    <!-- Specific DB Profile -->
     <profile>
       <id>Isolate</id>
       <activation>
@@ -576,8 +515,6 @@
         </plugins>
       </build>
     </profile>
-
-    <!-- Citus Profile, special case -->
     <profile>
       <id>citus</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -309,14 +309,14 @@
       <version>4.6</version>
     </dependency>
     <dependency>
-      <groupId>com.ing.data</groupId>
-      <artifactId>cassandra-jdbc-wrapper</artifactId>
-      <version>4.7.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.arangodb</groupId>
       <artifactId>arangodb-java-driver</artifactId>
       <version>6.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ing.data</groupId>
+      <artifactId>cassandra-jdbc-wrapper</artifactId>
+      <version>4.7.0</version>
     </dependency>
     <dependency>
       <groupId>ru.yandex.clickhouse</groupId>
@@ -324,14 +324,14 @@
       <version>0.3.2</version>
     </dependency>
     <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>42.5.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
       <version>1.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.5.1</version>
     </dependency>
   </dependencies>
   <reporting>


### PR DESCRIPTION
Python script to remove all unshared dependencies temporarily, insert necessary dependencies for the specific db, compile, then reverse all changes to pom.xml.

Currently unusable. I realised some dependencies are needed at runtime, will reinsert them accordingly.